### PR TITLE
undone dayIndex disabling

### DIFF
--- a/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosteringImporter.java
+++ b/src/main/java/org/optaplanner/examples/nurserostering/persistence/NurseRosteringImporter.java
@@ -168,6 +168,8 @@ public class NurseRosteringImporter extends AbstractXmlSolutionImporter<NurseRos
                 shiftDate.setId(id);
                 //not using dayIndex anymore, WaalbrugWire, 7-5-2018
                 //shiftDate.setDayIndex(dayIndex);
+                //above change caused some rules using dayindex not firing anymore, WaalbrugWire 27-9-2018
+                shiftDate.setDayIndex(dayIndex);
                 shiftDate.setDate(date);
                 shiftDate.setShiftList(new ArrayList<>());
                 shiftDateList.add(shiftDate);


### PR DESCRIPTION
This caused some rules to stop firing.where dayIndex was used to see if two shifts were consecutive shifts
like $dayIndex == dayIndex - 1